### PR TITLE
remove M{"Dir": "example"} from Start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As an example, create a file **"tasks/Gosufile.go"** with this content
 
         p.Task("server", D{"views"}, W{"**/*.go"}, Debounce(3000), func() {
             // Start recompiles and restarts on changes when watching
-            Start("main.go", M{"Dir": "example"})
+            Start("main.go")
         })
     }
 


### PR DESCRIPTION
when running example from README, got following error `tasks/Gosufile.go:20: cannot use gosu.M literal (type gosu.M) as type *gosu.Cmd in argument to gosu.Start`

seems Start takes a *Cmd so not sure of the intent, but this will help new users get up and going without an error
