### PR TITLE
Use gopkg.in/godo.v1 in pkg, cmd and generated code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ build:
 	@cd cmd/godo && go install
 
 get:
-	@go get -u github.com/go-godo/godo
-	@go get -u github.com/go-godo/godo/cmd/godo
+	@go get -u gopkg.in/godo.v1
+	@go get -u gopkg.in/godo.v1/cmd/godo
 

--- a/cmd.go
+++ b/cmd.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/go-godo/godo/util"
 	"github.com/mgutz/ansi"
+	"gopkg.in/godo.v1/util"
 )
 
 var spawnedProcesses = make(map[string]*os.Process)

--- a/cmd/godo/main.go
+++ b/cmd/godo/main.go
@@ -9,9 +9,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-godo/godo"
-	"github.com/go-godo/godo/util"
 	"github.com/mgutz/str"
+	"gopkg.in/godo.v1"
+	"gopkg.in/godo.v1/util"
 )
 
 func checkError(err error, format string, args ...interface{}) {
@@ -81,7 +81,7 @@ func buildMain(src string) string {
 		template := `
 	        package main
 	        import (
-	            "github.com/go-godo/godo"
+	            "gopkg.in/godo.v1"
 	            pkg "{{package}}"
 	        )
 	        func main() {

--- a/context.go
+++ b/context.go
@@ -1,8 +1,8 @@
 package godo
 
 import (
-	"github.com/go-godo/godo/watcher"
 	"gopkg.in/fsnotify.v1"
+	"gopkg.in/godo.v1/watcher"
 )
 
 // Context is the data passed to a task.

--- a/glob.go
+++ b/glob.go
@@ -12,7 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/MichaelTJones/walk"
-	"github.com/go-godo/godo/util"
+	"gopkg.in/godo.v1/util"
 )
 
 const (

--- a/project.go
+++ b/project.go
@@ -12,9 +12,9 @@ import (
 
 	flag "github.com/ogier/pflag"
 
-	"github.com/go-godo/godo/util"
-	"github.com/go-godo/godo/watcher"
 	"github.com/mgutz/str"
+	"gopkg.in/godo.v1/util"
+	"gopkg.in/godo.v1/watcher"
 )
 
 // M is generic string to interface alias

--- a/task.go
+++ b/task.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/go-godo/godo/util"
-	"github.com/go-godo/godo/watcher"
+	"gopkg.in/godo.v1/util"
+	"gopkg.in/godo.v1/watcher"
 )
 
 // TaskFunction is the signature of the function used to define a type.

--- a/tasks/Godofile.go
+++ b/tasks/Godofile.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	. "github.com/go-godo/godo"
 	"github.com/mgutz/goa"
 	f "github.com/mgutz/goa/filter"
 	"github.com/mgutz/str"
+	. "gopkg.in/godo.v1"
 )
 
 // Tasks is local project.
@@ -29,7 +29,7 @@ func Tasks(p *Project) {
 		// add godoc
 		goa.Pipe(
 			f.Load("./README.md"),
-			f.Str(str.ReplaceF("--", "\n[godoc](https://godoc.org/github.com/go-godo/godo)\n", 1)),
+			f.Str(str.ReplaceF("--", "\n[godoc](https://godoc.org/gopkg.in/godo.v1)\n", 1)),
 			f.Write(),
 		)
 	})


### PR DESCRIPTION
gopkg.in will only work properly if the package and command is using gopkg itself.

Imagine that at some point there's a breaking change required, either because it's needed or because it's just a new path that being taken. The `master` branch will contain these new changes and at some point be tagged `v2.0.0`. At that point people using the `v1` release with `gopkg.in/godo.v1` should still have working code, but since the pkg and cmd are now using github.com directly, they're using the `master` branch, and will probably fail to build.

I've also edited all source to use gopkg.in. Also updated the `Makefile` and `Godofile.go`.
