### PR TITLE
Must* and HTTP functions

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,29 @@
+package godo
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+func HTTPGetString(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func MustHTTPGetString(url string) string {
+	body, err := HTTPGetString(url)
+	if err != nil {
+		panic(&mustPanic{
+			err: err,
+		})
+	}
+	return body
+}

--- a/must.go
+++ b/must.go
@@ -1,0 +1,6 @@
+package godo
+
+type mustPanic struct {
+	// err is the original error that caused the panic
+	err error
+}


### PR DESCRIPTION
Sorry for having two features in one PR. The second feature requires the first one.

I have added a wrapper for simple HTTP GET's: HTTPGetString(url string) returns the HTTP GET response body as string and optionally an error.
That function is wrapped by MustHTTPGetString(url string), which doesnt return a second value (error), but instead panics when an error occurs. The panic is recovered at *Project.run(..) so it is nicely printed without stacktrace.

I think the Must\* approach can be used for multiple other godo helper functions.
