### PR TITLE
Set the env to value during the execution of the godo command

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -3,6 +3,7 @@ package godo
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	flag "github.com/ogier/pflag"
@@ -72,8 +73,19 @@ func Godo(tasksFunc func(*Project)) {
 		args = project.Tasks["default"].Dependencies
 	}
 
+	tasks := []string{}
 	for _, name := range args {
-		project.Run(name)
+		i := strings.Index(name, "=")
+		if i >= 0 {
+			key := name[:i]
+			value := name[i+1:]
+			os.Setenv(key, value)
+		} else {
+			tasks = append(tasks, name)
+		}
+	}
+	for _, task := range tasks {
+		project.Run(task)
 	}
 
 	if *watching {


### PR DESCRIPTION
Hello.
I tried to implement pass the ENV from the command line.

See below. (name=value option)
http://docs.seattlerb.org/rake/doc/command_line_usage_rdoc.html

**example**
```
godo hello USER=someone

(output)
Hello someone!
hello 13ms
```