### PR TITLE
Fix for #23 godo cmd

### DIFF
--- a/cmd/godo/main.go
+++ b/cmd/godo/main.go
@@ -67,7 +67,10 @@ func main() {
 	cmd = str.Clean(cmd)
 	// errors are displayed by tasks
 
-	godo.Run(cmd)
+	err := godo.Run(cmd)
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 type godorc struct {


### PR DESCRIPTION
exit with non-success error code if running task failed.
