### PR TITLE
Fix bug with runonce syntax : task not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 example/dist
 godobin*
 /cmd/godo/godo
+*.iml

--- a/project.go
+++ b/project.go
@@ -330,7 +330,7 @@ func (project *Project) Task(name string, dependencies Dependency, handler func(
 		task.dependencies = append(task.dependencies, dependencies)
 	}
 
-	project.Tasks[name] = task
+	project.Tasks[task.Name] = task
 	return task
 }
 


### PR DESCRIPTION
When using syntax "wonderfull-task?", the character "?" is well extract to setup runonce variable but the task name still remain "wonderfull-task?" in the project structure.
