### PR TITLE
project.go: use the parsed task.Name (without trailing `?`)

### DIFF
--- a/project.go
+++ b/project.go
@@ -344,7 +344,7 @@ func (project *Project) Task1(name string, handler func(*Context)) *Task {
 
 	task.Handler = HandlerFunc(handler)
 
-	project.Tasks[name] = task
+	project.Tasks[task.Name] = task
 	return task
 }
 
@@ -357,7 +357,7 @@ func (project *Project) TaskD(name string, dependencies Dependency) *Task {
 	}
 
 	task.dependencies = append(task.dependencies, dependencies)
-	project.Tasks[name] = task
+	project.Tasks[task.Name] = task
 	return task
 }
 


### PR DESCRIPTION
This is related to the fix in https://github.com/go-godo/godo/pull/33
