### PR TITLE
Flip `[flags] [task...]` in usage output

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -66,7 +66,7 @@ func Usage(tasks string) {
 	// go's flag package prints ugly screen
 	format := `godo %s - do task(s)
 
-Usage: godo [flags] [task...]
+Usage: godo [task...] [flags]
   -D             Print deprecated warnings
       --dump     Dump debug info about the project
   -h, --help     This screen


### PR DESCRIPTION
I was having issues running commands with flags and found the order in the `Usage` to be flipped. Here is some example output:

<img width="403" alt="screen shot 2016-10-10 at 4 55 01 pm" src="https://cloud.githubusercontent.com/assets/6809782/19254705/719706aa-8f0b-11e6-9e2b-58fea8f8bd73.png">

It seems easier to flip the output text then to flip the code itself and it doesn't break backwards compatibility,
