### PR TITLE
Add proper link to godoc documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # godo
 
-[godoc](https://godoc.org/github.com/mgutz/godo/v2)
+[![GoDoc](https://godoc.org/github.com/go-godo/godo?status.svg)](https://godoc.org/github.com/go-godo/godo)
 
 godo is a task runner and file watcher for golang in the spirit of
 rake, gulp.


### PR DESCRIPTION
The previous link was pointing to the old repo.