### PR TITLE
Suppress output when capturing it with RunOutput and BashOutput

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mgutz/ansi"
 	"gopkg.in/godo.v2/util"
 )
 
@@ -50,12 +49,12 @@ func (gcmd *command) toExecCmd() (cmd *exec.Cmd, err error) {
 	cmd.Stdin = os.Stdin
 
 	if gcmd.capture&CaptureStderr > 0 {
-		cmd.Stderr = newFileWrapper(os.Stderr, &gcmd.buf, ansi.Red)
+		cmd.Stderr = &gcmd.buf
 	} else {
 		cmd.Stderr = os.Stderr
 	}
 	if gcmd.capture&CaptureStdout > 0 {
-		cmd.Stdout = newFileWrapper(os.Stdout, &gcmd.buf, "")
+		cmd.Stdout = &gcmd.buf
 	} else {
 		cmd.Stdout = os.Stdout
 	}

--- a/context.go
+++ b/context.go
@@ -83,7 +83,6 @@ func (context *Context) BashOutput(script string, options ...map[string]interfac
 	s, err := Bash(script, options...)
 	if err != nil {
 		context.Error = err
-		return ""
 	}
 	return s
 }
@@ -98,7 +97,6 @@ func (context *Context) RunOutput(commandstr string, options ...map[string]inter
 	s, err := Run(commandstr, options...)
 	if err != nil {
 		context.Error = err
-		return ""
 	}
 	return s
 }


### PR DESCRIPTION
@goloroden asks how to suppress the command output when you are capturing it in https://github.com/go-godo/godo/issues/41.

I think this should be default behavior, since it is the expected behavior and is consistent with the standard library, for example [exec.Cmd.CombinedOutput](https://golang.org/pkg/os/exec/#Cmd.CombinedOutput). Plus, if the user wants to print the output he captures, he can always do it in his task.