### PR TITLE
Add LF at end of usage string when displayed alone

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -77,6 +77,7 @@ Usage: godo [flags] [task...]
   -w, --watch    Watch task and dependencies`
 
 	if tasks == "" {
+		format += "\n"
 		fmt.Printf(format, Version)
 	} else {
 		format += "\n\n%s"


### PR DESCRIPTION
Just a minor stylistic change to avoid having the shell prompt displaying on the same line as the last usage string line:

```
$ godo
godo 2.0.9 - do task(s)
[...]
  -w, --watch    Watch task and dependenciesbash-4.3$
```