### PR TITLE
Ignore the Go 1.5 vendor folder by default

### DIFF
--- a/watcher/fswatch/watcher.go
+++ b/watcher/fswatch/watcher.go
@@ -221,6 +221,11 @@ func ignorePathDefault(path string) bool {
 		return true
 	}
 
+	// ignore go vendor
+	if strings.HasPrefix(path, "vendor") || strings.Contains(path, "/vendor") {
+		return true
+	}
+
 	// vim creates random numeric files
 	base := filepath.Base(path)
 	if str.IsNumeric(base) {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -218,6 +218,11 @@ func DefaultIgnorePathFn(path string) bool {
 		return true
 	}
 
+	// ignore go vendor
+	if strings.HasPrefix(path, "vendor") || strings.Contains(path, "/vendor") {
+		return true
+	}
+
 	// vim creates random numeric files
 	base := filepath.Base(path)
 	if str.IsNumeric(base) {


### PR DESCRIPTION
Currently the watcher recursively checks all vendored Golang dependencies. This PR would reduce the number of files needed to be scanned.